### PR TITLE
Make it buildable by both SDK 1.5.1 and 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ set(FAMILY rp2040)
 set(BOARD pico_sdk)
 set(TINYUSB_DEBUG_LEVE 0)
 include(${PICO_TINYUSB_PATH}/hw/bsp/${FAMILY}/family.cmake)
-family_configure_target(picones)
+if (PICO_SDK_VERSION_MAJOR LESS 2)
+    family_configure_target(picones)
+else()
+    family_configure_target(picones "" )
+endif()
 # add_compile_definitions(CFG_TUSB_DEBUG=0)
 
 target_link_libraries(picones


### PR DESCRIPTION
For making the project build with SDK 1.5.1 and 2.0.0

- Changed CMakeLists.txt
- Linked tot latest pico_lib submodule

